### PR TITLE
Hide double/long press action in Home app when disabled (#143)

### DIFF
--- a/src/PicoRemote.ts
+++ b/src/PicoRemote.ts
@@ -201,9 +201,17 @@ export class PicoRemote {
             service.setCharacteristic(this.platform.api.hap.Characteristic.Name, alias.label);
             service.setCharacteristic(this.platform.api.hap.Characteristic.ServiceLabelIndex, alias.index);
 
+            const validValues = [this.platform.api.hap.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS]
+            if (this.options.clickSpeedDouble !== "disabled"){
+                validValues.push(this.platform.api.hap.Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS)
+            }
+            if (this.options.clickSpeedLong !== "disabled"){
+                validValues.push(this.platform.api.hap.Characteristic.ProgrammableSwitchEvent.LONG_PRESS)
+            }
+
             service
                 .getCharacteristic(this.platform.api.hap.Characteristic.ProgrammableSwitchEvent)
-                .setProps({ maxValue: 2 });
+                .setProps({ validValues, maxValue: 2 });
 
             this.services.set(button.href, service);
             this.trackers.set(


### PR DESCRIPTION
Only add DOUBLE_PRESS/LONG_PRESS to ProgrammableSwitchEvent's validValues when the option(s) are enabled

Tested locally on all 4 scenarios
- Single
- Single/Double
- Single/Long
- Single/Double/Long

One issue: When changing between enabled/disabled, user needs to delete the accessary cache on Homebridge web UI, then restart the bridge. User will lose existing settings

(Might look into this later)